### PR TITLE
#40 Exclude examples, tests, and external from Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "examples"
+  - "tests"
+  - "external"
+  - "build*/**"
+  - ".build*/**"
+  - "cmake-build-*/**"


### PR DESCRIPTION
## Summary

Codecov was instrumenting and counting `examples/` code alongside library sources, dragging the reported coverage ratio down. Add a `codecov.yml` at repo root to restrict the coverage metric to first-party library code.

## Changes

- `codecov.yml` — new file
  - `ignore:` — `examples/`, `tests/`, `external/`, and all build trees (`build*/`, `.build*/`, `cmake-build-*/`) at any depth
  - `threshold: 1%` on project and patch status, to keep tiny fluctuations from flipping the check red

## Rationale

- **examples/** — demo code, not library code; excluding it is the point of this PR
- **tests/** — you don't measure coverage *of* test code, only *by* it; Codecov's convention is to exclude
- **external/** — vendored / third-party, out of scope
- **build trees** — catches any stray \`.gcno\` / \`.gcda\` paths the uploader might surface

## Test plan

- [ ] Next Ubuntu CI run uploads coverage, Codecov applies the new ignore list
- [ ] Reported coverage reflects \`include/\`, \`src/\`, and \`private/\` only
- [ ] Badge number rises to a realistic value for library + scheduler code