### PR TITLE
Exclude non-library code from Codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "examples"
+  - "tests"
+  - "external"
+  - "build*/**"
+  - ".build*/**"
+  - "cmake-build-*/**"


### PR DESCRIPTION
Closes #65.

## Summary

Add a `codecov.yml` at the repo root so Codecov restricts its coverage ratio to first-party library code. Without this, `examples/`, `tests/`, and build-tree paths inflate the denominator and the badge reports an artificially low number.

## Changes

- `codecov.yml` — new file
  - `ignore:` list excludes `examples/`, `tests/`, `external/`, and top-level build trees (`build*/`, `.build*/`, `cmake-build-*/`)
  - `threshold: 1%` on both project and patch status so tiny fluctuations don't flip the check red

## Rationale

- **examples/** — demo code, not library code
- **tests/** — coverage measures how much of the **library** was exercised by tests. Including test files in the ratio counts them toward the denominator, which is meaningless: you don't grade a microscope on how well it sees itself
- **external/** — vendored / third-party, out of scope
- **build trees** — catches any paths surfacing from generated headers (e.g. `build/gempba/config.h`) or gcov artifacts

## Patterns — subtle detail

Codecov translates glob patterns to regex. Plain folder names (`examples`) become prefix matches (`^examples.*`) and correctly catch every file underneath. Wildcarded names like `build*` need an explicit `/**` suffix (`build*/**`) to match files under the directory rather than just the bare directory name — verified against `codecov/validate`.

## Test plan

- [x] `codecov.yml` validates against `https://codecov.io/validate`
- [ ] Next Ubuntu CI run uploads coverage and Codecov applies the ignore list
- [ ] Reported coverage reflects `include/`, `src/`, and `private/` only
- [ ] Codecov badge rises to a realistic value for library + scheduler code