### PR TITLE
Release v3.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(gempba VERSION 3.1.0 LANGUAGES CXX)
+project(gempba VERSION 3.1.1 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/docs/releases/release-notes-v3.1.1.md
+++ b/docs/releases/release-notes-v3.1.1.md
@@ -1,0 +1,43 @@
+# v3.1.1
+
+<small>May 2, 2026 · [GitHub ↗](https://github.com/rapastranac/gempba/releases/tag/v3.1.1)</small>
+
+Post-v3.1.0 hygiene release: packaging metadata, coverage scope, CI workflow polish, a test-coverage push, cross-platform fixes, and toolchain bumps. No public API changes.
+
+**Changed**
+
+- `gempba::create_custom_node` now takes a `std::shared_ptr<node_core>` directly (no more wrapping at the call site)
+- `wall_time` reimplemented on top of `std::chrono` (replaces `gettimeofday`) — same observable values, monotonic clock semantics
+- `gempba::log_and_throw` marked `[[noreturn]]` so static analyzers and the compiler's flow analysis understand the call never returns
+- `score`: cleaned up the `kind` / `to_raw` / `from_raw` paths and added explicit `unreachable` markers
+- `node_core_impl`: lazy-init and result paths consolidated; redundant explicit destructor on `node` removed; excessive debug logging trimmed
+- Codebase-wide `clang-tidy` identifier-naming pass (private members and locals only — no public API renames)
+
+**Removed**
+
+- Dead `prune()` overload in `work_stealing_load_balancer`
+- Unreachable defensive checks in `get_root_level_pending_node`
+
+**Fixed**
+
+- `gempba::utils::get_nb_set_bits` signed-`char` overflow on MinGW
+- MSYS2/MinGW build: `<windows.h>` is now included before `<psapi.h>` so `psapi.h` sees the types it needs
+- `centralized_utils.hpp`: `NOMINMAX` redefinition guarded so headers that already define it don't trigger a warning
+- `node.hpp`: `<stacktrace>` inclusion gated on the `__cpp_lib_stacktrace` feature test, not just `__has_include`
+
+**Build**
+
+- MSYS2 `PKGBUILD` `sha256` updated to match the v3.1.0 source tarball
+- Codecov reporting now excludes `examples/`, `tests/`, and `external/` so coverage numbers reflect only library code
+- New `clang-tidy` and `clang-format` identifier-naming and configuration rules so future changes can't reintroduce the patterns just cleaned up
+- Ubuntu CI bumped to GCC 14; `<stacktrace>` and `stdc++exp` linkage gated accordingly so older toolchains still build the library
+- macOS CI defaults to the `macos-26` runner image
+- Self-hosted runners are now matched by label *set* (multiple labels combined) rather than a single label
+- MS-MPI runtime installed on the Windows CI runner so the multiprocessing test set actually runs
+- `clang-format` diagnostics surfaced with the colored summary; `lint.sh` diagnostics made readable on the terminal
+- Skip the `publish-test-results` job when the upstream build was cancelled
+- `runs-on` injected from `vars.RUNNER_*` repository variables so runner targets can change without editing each workflow
+- New full-coverage tests for the `gempba` facade, `node_manager`, `quasi_horizontal_load_balancer`, `work_stealing_load_balancer`, `node_core_impl`, `centralized_utils`, plus branch coverage for `queue`, `utils`, `score`, and `node`
+- Thread pool readiness ordering tightened in throw/discard tests so the `send()` race no longer deflakes them
+- Dropped flaky peak-vs-current RSS comparisons from the memory-usage tests
+- `-Wunused` warnings silenced on header-only helpers

--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gempba
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.1.0
+pkgver=3.1.1
 pkgrel=1
 pkgdesc="Generic Massive Parallelisation of Branching Algorithms — parallel branch-and-bound C++23 framework (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
Closes #68

**Problem**
- v3.1.1 needs to be cut so the post-v3.1.0 hygiene cluster (cherry-picked from origin `e865604..65ecec0`) gets its own tag with correctly-labelled `.deb` and MSYS2 packages.
- Building from the cherry-picked tip without bumping the source-of-truth version files would publish 3.1.1-tagged packages that internally identify as 3.1.0.

**Fix / Solution**
- `CMakeLists.txt` — `project(gempba VERSION 3.1.0 LANGUAGES CXX)` → `3.1.1`
- `packaging/msys2/PKGBUILD` — `pkgver=3.1.0` → `3.1.1`
- `docs/releases/release-notes-v3.1.1.md` — added, copied verbatim from the origin iter-2 branch.
- `sha256sums` in `PKGBUILD` intentionally left stale; the workflow patches it to `SKIP` at build time. A follow-up commit (mirroring [`94bd183`](https://github.com/apdistributedsystems/gempba/commit/94bd183810c48526db808f33815539e81ea0a7d9) for v3.1.0) will land the real sha256 once the v3.1.1 source tarball exists on GitHub.

**Tests**
- N/A — release-bump only. CI runs on the merge commit; tag + Release happen after merge.