### PR TITLE
Release v3.2.0 — update PKGBUILD sha256

### DIFF
--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=('staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rapastranac/gempba/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('bbaaef97fa2dffbe01c55feb8fcea32dd185b638b63ce670fd3053acb35a6ce9')
+sha256sums=('7fca8be2f36bab3d5370dcb4a68e02cadbfb707f0f96e738bac02eeeb85959e2')
 
 build() {
     mkdir -p "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Closes #71

**Problem**
- The v3.2.0 release-bump PR (#72) committed `packaging/msys2/PKGBUILD` with the stale `sha256sums` from v3.1.1. MSYS2 consumers running `makepkg` against the committed PKGBUILD see a checksum mismatch against the GitHub-published source tarball for `v3.2.0`.

**Fix / Solution**
- Replace `sha256sums=('bbaaef97…')` (v3.1.1 hash) with the real sha256 of `https://github.com/rapastranac/gempba/archive/refs/tags/v3.2.0.tar.gz`: `7fca8be2f36bab3d5370dcb4a68e02cadbfb707f0f96e738bac02eeeb85959e2`.
- Same iteration-2 pattern as #70 for v3.1.1 and [`94bd183`](https://github.com/apdistributedsystems/gempba/commit/94bd183810c48526db808f33815539e81ea0a7d9) for v3.1.0.

**Tests**
- N/A — packaging metadata only.