### PR TITLE
Release v3.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(gempba VERSION 3.2.0 LANGUAGES CXX)
+project(gempba VERSION 3.2.1 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/docs/releases/release-notes-v3.2.1.md
+++ b/docs/releases/release-notes-v3.2.1.md
@@ -1,0 +1,18 @@
+# v3.2.1
+
+<small>May 6, 2026 · [GitHub ↗](https://github.com/rapastranac/gempba/releases/tag/v3.2.1)</small>
+
+Stability follow-up to the v3.2.0 telemetry scaffold: a critical multi-rank fix, hardening of static-init paths, and a pinned external dependency.
+
+**Fixed**
+
+- MPI deadlock when telemetry was installed on some ranks but not others — every rank now agrees on whether the telemetry transport is wired up, so peers don't block waiting on traffic that will never come ([#70](https://github.com/rapastranac/gempba/pull/71))
+- `debug_logger_initializer` constructor marked `noexcept` so it cannot throw during static initialization (caught by `clang-tidy`'s `bugprone-throwing-static-initialization`) — a thrown exception there would have terminated the program before `main`
+
+**Changed**
+
+- `BS::thread_pool` pinned to `v5.1.0.1` instead of tracking `master`, so reproducible builds no longer drift when upstream changes ([#77](https://github.com/rapastranac/gempba/pull/78))
+
+**Build**
+
+- CI `clang-tidy` bumped from 18 to 19

--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gempba
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.2.0
+pkgver=3.2.1
 pkgrel=1
 pkgdesc="Generic Massive Parallelisation of Branching Algorithms — parallel branch-and-bound C++23 framework (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
Closes #74

**Problem**
- v3.2.1 needs to be cut so the telemetry-stability cluster (clang-tidy 19 + throwing-static-init fix, MPI deadlock from asymmetric telemetry install, BS::thread_pool pin) gets its own tag with correctly-labelled `.deb` and MSYS2 packages.
- Building from the cherry-picked tip without bumping the source-of-truth version files would publish 3.2.1-tagged packages that internally identify as 3.2.0.

**Fix / Solution**
- `CMakeLists.txt` — `project(gempba VERSION 3.2.0 LANGUAGES CXX)` → `3.2.1`
- `packaging/msys2/PKGBUILD` — `pkgver=3.2.0` → `3.2.1`
- `docs/releases/release-notes-v3.2.1.md` — added, copied verbatim from the origin iter-2 branch.
- `sha256sums` in `PKGBUILD` intentionally left stale; `publish-msys2` patches it to `SKIP` at build time. The real sha256 for the v3.2.1 source tarball lands in a separate follow-up iteration (mirroring #70 for v3.1.1 and #73 for v3.2.0).

**Tests**
- N/A — release-bump only. CI runs on the merge commit; tag + Release happen after merge.