### PR TITLE
Release v3.2.1 — update PKGBUILD sha256

### DIFF
--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=('staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rapastranac/gempba/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('7fca8be2f36bab3d5370dcb4a68e02cadbfb707f0f96e738bac02eeeb85959e2')
+sha256sums=('f367871e07a743a45600709695e13a2f50c608151af90ebd186588a957cc6045')
 
 build() {
     mkdir -p "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Closes #74

**Problem**
- The v3.2.1 release-bump PR (#75) committed `packaging/msys2/PKGBUILD` with the stale `sha256sums` from v3.2.0. MSYS2 consumers running `makepkg` against the committed PKGBUILD see a checksum mismatch against the GitHub-published source tarball for `v3.2.1`.

**Fix / Solution**
- Replace `sha256sums=('7fca8be2…')` (v3.2.0 hash) with the real sha256 of `https://github.com/rapastranac/gempba/archive/refs/tags/v3.2.1.tar.gz`: `f367871e07a743a45600709695e13a2f50c608151af90ebd186588a957cc6045`.
- Same iteration-2 pattern as #70 (v3.1.1) and #73 (v3.2.0).

**Tests**
- N/A — packaging metadata only.