### PR TITLE
Release v3.3.0 — update PKGBUILD sha256

### DIFF
--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=('staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rapastranac/gempba/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('f367871e07a743a45600709695e13a2f50c608151af90ebd186588a957cc6045')
+sha256sums=('c4295cdb533a8a469ca1d2b2e52f47533b33c2489735e8da9df70ee65a55482a')
 
 build() {
     mkdir -p "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Closes #77

**Problem**
- The v3.3.0 release-bump PR (#78) committed `packaging/msys2/PKGBUILD` with the stale `sha256sums` from v3.2.1. MSYS2 consumers running `makepkg` against the committed PKGBUILD see a checksum mismatch against the GitHub-published source tarball for `v3.3.0`.

**Fix / Solution**
- Replace `sha256sums=('f367871e…')` (v3.2.1 hash) with the real sha256 of `https://github.com/rapastranac/gempba/archive/refs/tags/v3.3.0.tar.gz`: `c4295cdb533a8a469ca1d2b2e52f47533b33c2489735e8da9df70ee65a55482a`.
- Same iteration-2 pattern as #70 (v3.1.1), #73 (v3.2.0), #76 (v3.2.1).

**Tests**
- N/A — packaging metadata only.