### PR TITLE
Release v4.0.0 — update PKGBUILD sha256

### DIFF
--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -25,7 +25,7 @@ makedepends=(
 )
 options=('staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rapastranac/gempba/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('c4295cdb533a8a469ca1d2b2e52f47533b33c2489735e8da9df70ee65a55482a')
+sha256sums=('f6ea059eda86727931561248bb95e15044056e447793f0ad541cffc65ec7f40a')
 
 build() {
     mkdir -p "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Closes #80

**Problem**
- The v4.0.0 release-bump PR (#84) committed `packaging/msys2/PKGBUILD` with the stale `sha256sums` from v3.3.0. MSYS2 consumers running `makepkg` against the committed PKGBUILD see a checksum mismatch against the GitHub-published source tarball for `v4.0.0`.

**Fix / Solution**
- Replace `sha256sums=('c4295cdb…')` (v3.3.0 hash) with the real sha256 of `https://github.com/rapastranac/gempba/archive/refs/tags/v4.0.0.tar.gz`: `f6ea059eda86727931561248bb95e15044056e447793f0ad541cffc65ec7f40a`.
- Same iteration-2 pattern as #70 (v3.1.1), #73 (v3.2.0), #76 (v3.2.1), #79 (v3.3.0).

**Tests**
- N/A — packaging metadata only.