### PR TITLE
Release v3.1.1 — update PKGBUILD sha256

### DIFF
--- a/packaging/msys2/PKGBUILD
+++ b/packaging/msys2/PKGBUILD
@@ -23,7 +23,7 @@ makedepends=(
 )
 options=('staticlibs')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/rapastranac/gempba/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('cd9b77d1d94b764b8e0d3a02f0ad57f9cd2f13c1580cfcf56a1f37a610cfa088')
+sha256sums=('c7a7c771fe3f7038228e08da540cc0461df04416821a09974b34e52c9beb5fbb')
 
 build() {
     mkdir -p "${srcdir}/build-${MSYSTEM}"


### PR DESCRIPTION
Closes https://github.com/rapastranac/gempba/issues/68

Problem

The v3.1.1 release-bump PR (https://github.com/rapastranac/gempba/pull/69) committed packaging/msys2/PKGBUILD with a stale sha256sums. MSYS2 consumers running makepkg against the committed PKGBUILD see a checksum mismatch against the GitHub-published source tarball for v3.1.1.
Fix / Solution

Replace sha256sums=('cd9b77d…') with the real sha256 of https://github.com/rapastranac/gempba/archive/refs/tags/v3.1.1.tar.gz: bbaaef97fa2dffbe01c55feb8fcea32dd185b638b63ce670fd3053acb35a6ce9.
Mirrors the v3.1.0 follow-up pattern in [94bd183](https://github.com/apdistributedsystems/gempba/commit/94bd183810c48526db808f33815539e81ea0a7d9).
Tests

N/A — packaging metadata only.
Note

scripts/update-pkgbuild.sh reads from origin, which in the porting clone points at the private org repo where the tag doesn't exist. The sha256 here was produced by hand against upstream; teaching the script to honor an upstream override is a follow-up worth its own issue.